### PR TITLE
Fix remote ssh commands

### DIFF
--- a/chefsolo/provisioner_config.go
+++ b/chefsolo/provisioner_config.go
@@ -115,9 +115,10 @@ func Provisioner() terraform.ResourceProvisioner {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"recreate_client": {
+			"skip_install": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  false,
 			},
 			"prevent_sudo": {
 				Type:     schema.TypeBool,
@@ -178,6 +179,7 @@ func configureProvisioner(d *schema.ResourceData, osType afero.Fs) (*provisioner
 		ClientOptions:    getStringList(d.Get("client_options")),
 		Environment:      d.Get("environment").(string),
 		UsePolicyfile:    d.Get("use_policyfile").(bool),
+		SkipInstall:      d.Get("skip_install").(bool),
 		HTTPProxy:        d.Get("http_proxy").(string),
 		HTTPSProxy:       d.Get("https_proxy").(string),
 		NOProxy:          getStringList(d.Get("no_proxy")),

--- a/chefsolo/provisioner_utils.go
+++ b/chefsolo/provisioner_utils.go
@@ -42,6 +42,12 @@ func getCommunicator(ctx context.Context, o terraform.UIOutput, s *terraform.Ins
 	if err != nil {
 		return nil, err
 	}
-	defer comm.Disconnect()
+
+	// Wait for the context to end and then disconnect
+	go func() {
+		<-ctx.Done()
+		comm.Disconnect()
+	}()
+
 	return comm, err
 }


### PR DESCRIPTION
Hi, 

thanks a lot for that chef-solo provisioner! We use it to provision some VMs in Alicloud. While testing I found out that ssh connections are not working reliable in our setup - but a remote-exec resource did. So I simply used the same method to create the remote connection. That works without problems for us.

Additionally I activated the "skip_install" parameter to save time during provisioning.

Please consider merging that two small patches.

thx & best regards,
Andreas